### PR TITLE
Update blah_index.properties

### DIFF
--- a/blah_index.properties
+++ b/blah_index.properties
@@ -213,11 +213,12 @@ map.format.q = Kit
 map.format.r = Slide
 map.format.s = Playbill
 map.format.t = Thesis
-map.format.v = Video
+map.format.v = Video cassette
 #w - Book w/disk
 map.format.w = Book
 #x - Xerox
 map.format.x = Photocopy
+map.format.y = Blu-ray Disc
 map.format.@ = E-Book
 map.format = Unknown
 


### PR DESCRIPTION
As discussed on ICT ticket F200396006. Since indexing is run from the blah-solmarc/dist folder, replicating change made to index properties file in blah. This has been tested in a development instance. Changes are to accommodate new item formats, and a re-index of the test (and then production) systems is also required.