### PR TITLE
Lbc 23

### DIFF
--- a/blah_index.properties
+++ b/blah_index.properties
@@ -95,7 +95,7 @@ edition_display = custom, removeTrailingPunct(250ab)
 #############################################
 # Call/Class number fields
 #############################################
-lc_callnum_display = 050ab, first
+lc_callnum_display = 050abf, first
 lc_1letter_facet = 050a[0], callnumber_map.properties, first
 lc_alpha_facet = 050a, (pattern_map.lc_alpha), first
 lc_b4cutter_facet = 050a, first

--- a/blah_index.properties
+++ b/blah_index.properties
@@ -221,6 +221,8 @@ map.format.w = Book
 map.format.x = Photocopy
 map.format.y = Blu-ray Disc
 map.format.@ = E-Book
+map.format.& = E-Thesis
+map.format.! = Sheet
 map.format = Unknown
 
 pattern_map.lc_alpha.pattern_0 = ^([A-Z]{1,3})\\d+.*=>$1

--- a/blah_index.properties
+++ b/blah_index.properties
@@ -74,8 +74,8 @@ author_facet = custom, getLinkedFieldCombined(100abcdegqu:110abcdegnu:111[a-z]:7
 #############################################
 # Subject fields
 #############################################
-subject_t = custom, getLinkedFieldCombined(600[a-u]:610[a-u]:611[a-u]:630[a-t]:650[a-e]:651ae:653aa:654[a-e]:655[a-c])
-subject_addl_t = custom, getLinkedFieldCombined(600[v-z]:610[v-z]:611[v-z]:630[v-z]:650[v-z]:651[v-z]:654[v-z]:655[v-z])
+subject_t = custom, getLinkedFieldCombined(600[a-z]:610[a-z]:611[a-z]:630[a-z]:650[a-z]:651[a-z]:653aa:654[a-z]:655[a-z])
+subject_addl_t = ""
 subject_topic_facet = custom, removeTrailingPunct(600abcdq:610ab:611ab:630aa:650aa:653aa:654ab:655ab)
 subject_era_facet = custom, removeTrailingPunct(650y:651y:654y:655y)
 subject_geo_facet = custom, removeTrailingPunct(651a:650z)


### PR DESCRIPTION
1. Subject terms: include all subfields in subject definition,  preventing splitting of composite terms across "subject" and "additional  subject"

2. Accommodate new Material Types: "E-thesis" and "Sheet" defined in  Sierra. Electronic format requires a new index partial. Icons for all  formats revised and rationalized

3. Correct bibliographic data class numbers: prefix stored in the f subfield not currently indexed (e.g. "q" for quarto volumes)

Changes to blah_index.properties also applied in the blah repository

