### PR TITLE
Hyphenate subject terms at the subfield

### DIFF
--- a/blah_index.properties
+++ b/blah_index.properties
@@ -74,7 +74,7 @@ author_facet = custom, getLinkedFieldCombined(100abcdegqu:110abcdegnu:111[a-z]:7
 #############################################
 # Subject fields
 #############################################
-subject_t = custom, getLinkedFieldCombined(600[a-z]:610[a-z]:611[a-z]:630[a-z]:650[a-z]:651[a-z]:653aa:654[a-z]:655[a-z])
+subject_t = custom, getAllSubfields(600[a-z]:610[a-z]:611[a-z]:630[a-z]:650[a-z]:651[a-z]:653aa:654[a-z]:655[a-z]," -- ")
 subject_addl_t = ""
 subject_topic_facet = custom, removeTrailingPunct(600abcdq:610ab:611ab:630aa:650aa:653aa:654ab:655ab)
 subject_era_facet = custom, removeTrailingPunct(650y:651y:654y:655y)


### PR DESCRIPTION
UAT feedback on CER‌-0009 highlighted the value of hyphenating subject terms. The custom indexing method used for subject_t does not have the option of specifying a seperator other than the default space.  However, getAllSubfields does. If this method is used when indexing subject_t, with the hyphenation string set as a parameter, the desired result is achieved.